### PR TITLE
Scheduler & Scheduling Bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,11 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
+    - "3.7"
+    - "3.8"
 matrix:
   include:
-    - python: 3.7
+    - python: 3.8
       dist: xenial
       sudo: true
 install:

--- a/README.md
+++ b/README.md
@@ -6,10 +6,21 @@
 - Validate unix cron expression
 - Match unit cron expression with specific datetime 
 - Generate match datetime between two datetime
+- Schedule tasks
 
 ### **Install**
 ```shell script
 pip install cron-validator
+```
+
+### **Run Tests**
+**1. Install test requirements**
+```shell script
+pip install -r requirements/test.txt
+```
+**2. Run tests (with coverage if wished)**
+```shell script
+pytest --cov=. test/
 ```
 
 ### Sample
@@ -58,6 +69,20 @@ from_dt=str_to_datetime(from_str), to_dt=str_to_datetime(to_str)):
 # Output:
 # 2019-04-22 00:00:00+00:00
 # 2019-04-23 00:00:00+00:00
+```
+
+
+**4. Use scheduler for repetitive task**
+```python
+from cron_validator import CronScheduler
+
+cron_string = "*/1 * * * *"
+scheduler = CronScheduler(cron_string)
+
+while True:
+    if scheduler.time_for_execution():
+        # Get's called every full minute (excluding first iteration)
+        print("Now is the next scheduled time.")
 ```
 
 ### License

--- a/cron_validator/__init__.py
+++ b/cron_validator/__init__.py
@@ -1,1 +1,2 @@
 from .validator import CronValidator
+from .scheduler import CronScheduler

--- a/cron_validator/regexes.py
+++ b/cron_validator/regexes.py
@@ -89,7 +89,7 @@ class Element(object):
         attribute = maps.get(self.part)
         if attribute:
             return dt.__getattribute__(attribute)
-        return dt.weekday()
+        return self._convert_weekday(dt.weekday())
 
     def match(self, dt):
         """
@@ -98,6 +98,26 @@ class Element(object):
         :return:
         """
         raise NotImplementedError()
+
+    @staticmethod
+    def _convert_weekday(weekday):
+        """ converts the weekday from starting from a week starting from Monday to a week starting from Sunday
+
+        For the official crontab documentation (https://man7.org/linux/man-pages/man5/crontab.5.html (2020-09-20)) it
+        can be seen that their week starts on Sunday, which means SUN = 0, MON = 1, ..., SAT = 6. However, for the
+        package dateutil, which performs the actual scheduling, the week starts on a Monday, which means MON = 1,
+        TUE = 2, ..., SUN = 6. Since this package shall imitate the real cron syntax to avoid further confusion, the
+        weekday is converted to a week where SUN = 0. Nb. the official cron documentation states that 7 shall also be a
+        valid input and be corresponding to SUN leading to a week where MON = 1, TUE = 2, ..., SUN = 7. This method
+        respects that, however the regex only allows the maximal input of 6.
+        :param weekday: integer representing weekday, assuming MON = 1, TUE = 2, ..., SUN = 6
+        :return: integer representing passed weekday, however the week starts on Sunday meaning SUN = 0, MON = 1, ...
+        """
+        if weekday <= 5:
+            weekday_week_starting_sunday = weekday + 1
+        else:
+            weekday_week_starting_sunday = 0
+        return weekday_week_starting_sunday
 
 
 class MatchAllElement(Element):

--- a/cron_validator/scheduler.py
+++ b/cron_validator/scheduler.py
@@ -1,0 +1,27 @@
+import datetime
+
+from cron_validator.validator import CronValidator
+
+
+class CronScheduler(CronValidator):
+
+    def __init__(self, expression):
+        super().__init__()
+        self.gen = self.get_execution_time(expression, None, None)
+        self.next_execution_time = next(self.gen)
+
+    def time_for_execution(self):
+        now_rounded = self._round_down_to_nearest_minute(datetime.datetime.now())
+        is_time_for_execution = False
+
+        if now_rounded == self.next_execution_time:
+            self.next_execution_time = next(self.gen)
+            is_time_for_execution = True
+
+        return is_time_for_execution
+
+    @staticmethod
+    def _round_down_to_nearest_minute(dt):
+        return dt - datetime.timedelta(minutes=dt.minute % 1,
+                                       seconds=dt.second,
+                                       microseconds=dt.microsecond)

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,3 +2,4 @@
 pytest>=3.6
 pytest-cov
 coveralls
+freezegun

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ else:
 setup(
     name='cron-validator',
     packages=['cron_validator'],
-    version='1.0.1',
+    version='1.0.2',
     license='MIT',
     description='Unix cron implementation by Python',
     long_description=long_description,
@@ -19,8 +19,8 @@ setup(
     author='vcoder',
     author_email='doanngocbao@gmail.com',
     url='https://github.com/vcoder4c/cron-validator',
-    keywords=['cron', 'python', 'cron expression validator', 'cron expression iterator'],
-    download_url='https://github.com/vcoder4c/cron-validator/archive/v1.0.1.tar.gz',
+    keywords=['cron', 'python', 'cron expression validator', 'cron expression iterator', 'cron scheduler'],
+    download_url='https://github.com/vcoder4c/cron-validator/archive/v1.0.2.tar.gz',
     install_requires=[
         'python_dateutil',
         'pytz'

--- a/test/test_CronScheduler.py
+++ b/test/test_CronScheduler.py
@@ -1,0 +1,78 @@
+import datetime
+
+import pytest
+from freezegun import freeze_time
+
+from cron_validator.scheduler import CronScheduler
+
+
+def test_round_to_nearest_minute():
+    non_rounded_date = datetime.datetime(year=2020, month=8, day=15, hour=12, minute=24, second=28, microsecond=21)
+    rounded_date = CronScheduler._round_down_to_nearest_minute(non_rounded_date)
+    expected_date = datetime.datetime(year=2020, month=8, day=15, hour=12, minute=24, second=0, microsecond=0)
+    assert expected_date == rounded_date
+
+    non_rounded_date = datetime.datetime(year=2024, month=7, day=16, hour=18, minute=45, second=15, microsecond=42214)
+    rounded_date = CronScheduler._round_down_to_nearest_minute(non_rounded_date)
+    expected_date = datetime.datetime(year=2024, month=7, day=16, hour=18, minute=45, second=0, microsecond=0)
+    assert expected_date == rounded_date
+
+
+def test_time_for_execution_minutely():
+    # Every minute a certain task should be performed
+    cron_string = "*/1 * * * *"
+    initial_datetime = datetime.datetime(year=2020, month=9, day=1, hour=13, minute=23, second=4)
+    ten_next_execution_times = [datetime.datetime(year=2020, month=9, day=1, hour=13, minute=23, second=4),
+                                datetime.datetime(year=2020, month=9, day=1, hour=13, minute=24, second=0),
+                                datetime.datetime(year=2020, month=9, day=1, hour=13, minute=25, second=0),
+                                datetime.datetime(year=2020, month=9, day=1, hour=13, minute=26, second=0),
+                                datetime.datetime(year=2020, month=9, day=1, hour=13, minute=27, second=0),
+                                datetime.datetime(year=2020, month=9, day=1, hour=13, minute=28, second=0),
+                                datetime.datetime(year=2020, month=9, day=1, hour=13, minute=29, second=0),
+                                datetime.datetime(year=2020, month=9, day=1, hour=13, minute=30, second=0),
+                                datetime.datetime(year=2020, month=9, day=1, hour=13, minute=31, second=0),
+                                datetime.datetime(year=2020, month=9, day=1, hour=13, minute=32, second=0)]
+
+    n = 0
+    with freeze_time(initial_datetime) as frozen_datetime:
+        scheduler = CronScheduler(cron_string)
+
+        while is_run_condition(n):
+            if scheduler.time_for_execution():
+                assert datetime.datetime.now() == ten_next_execution_times[n]
+                n += 1
+            frozen_datetime.tick(1)
+
+
+@pytest.mark.skip("It seems like CronValidator has a bug when dealing with complicated cron jobs. Till that bug is fixed,"
+                  " this test is skipped since this class relies on the functionality of CronValidator.")
+def test_time_for_execution_complicated_cron():
+    # More complicated scheduling: At every 5th minute past every hour from 1 through 6 on every day-of-week from
+    # Tuesday through Thursday in March.
+    cron_string = "*/5 1-6 * 3 2-4"
+
+    initial_datetime = datetime.datetime(year=2021, month=2, day=24, hour=9, minute=21, second=46)
+    ten_next_execution_times = [datetime.datetime(year=2021, month=3, day=2, hour=1, minute=0, second=0),
+                                datetime.datetime(year=2021, month=3, day=2, hour=1, minute=5, second=0),
+                                datetime.datetime(year=2021, month=3, day=2, hour=1, minute=10, second=0),
+                                datetime.datetime(year=2021, month=3, day=2, hour=1, minute=15, second=0),
+                                datetime.datetime(year=2021, month=3, day=2, hour=1, minute=20, second=0),
+                                datetime.datetime(year=2021, month=3, day=2, hour=1, minute=25, second=0),
+                                datetime.datetime(year=2021, month=3, day=2, hour=1, minute=30, second=0),
+                                datetime.datetime(year=2021, month=3, day=2, hour=1, minute=35, second=0),
+                                datetime.datetime(year=2021, month=3, day=2, hour=1, minute=40, second=0),
+                                datetime.datetime(year=2021, month=3, day=2, hour=1, minute=45, second=0)]
+
+    n = 0
+    with freeze_time(initial_datetime) as frozen_datetime:
+        scheduler = CronScheduler(cron_string)
+
+        while is_run_condition(n):
+            if scheduler.time_for_execution():
+                assert datetime.datetime.now() == ten_next_execution_times[n]
+                n += 1
+            frozen_datetime.tick(1)
+
+
+def is_run_condition(n):
+    return n < 10

--- a/test/test_CronScheduler.py
+++ b/test/test_CronScheduler.py
@@ -44,8 +44,6 @@ def test_time_for_execution_minutely():
             frozen_datetime.tick(1)
 
 
-@pytest.mark.skip("It seems like CronValidator has a bug when dealing with complicated cron jobs. Till that bug is fixed,"
-                  " this test is skipped since this class relies on the functionality of CronValidator.")
 def test_time_for_execution_complicated_cron():
     # More complicated scheduling: At every 5th minute past every hour from 1 through 6 on every day-of-week from
     # Tuesday through Thursday in March.

--- a/test/test_execution_time.py
+++ b/test/test_execution_time.py
@@ -163,7 +163,7 @@ def test_generate_execution_time_from_day_of_week_match():
                                                to_dt=str_to_datetime(to_str)):
         print(dt)
         dts.append(dt)
-    assert len(dts) == 1
+    assert len(dts) == 0
 
     print('--------------------------------------------------')
     dts = list()

--- a/test/test_match.py
+++ b/test/test_match.py
@@ -66,16 +66,16 @@ def test_match_month():
 
 
 def test_match_day_of_week():
-    dt_str = '2019-04-23 1:00'
+    dt_str = '2019-04-23 1:00'  # Is a Tuesday
     dt = str_to_datetime(dt_str)
 
     assert CronValidator.match_datetime("* * * * *", dt)
-    assert CronValidator.match_datetime("* * * * 1", dt)
+    assert CronValidator.match_datetime("* * * * 2", dt)
     assert CronValidator.match_datetime("* * * * 5", dt) is False
-    assert CronValidator.match_datetime("* * * * 1-5", dt)
-    assert CronValidator.match_datetime("* * * * 1-3", dt)
-    assert CronValidator.match_datetime("* * * * 1/5", dt)
+    assert CronValidator.match_datetime("* * * * 2-5", dt)
+    assert CronValidator.match_datetime("* * * * 2-3", dt)
+    assert CronValidator.match_datetime("* * * * 2/5", dt)
     assert CronValidator.match_datetime("* * * * 5/1", dt) is False
     assert CronValidator.match_datetime("* * * * 1/1", dt)
-    assert CronValidator.match_datetime("* * * * 2,3,4", dt) is False
+    assert CronValidator.match_datetime("* * * * 3,4,5", dt) is False
     assert CronValidator.match_datetime("* * * * 2,3,1", dt)


### PR DESCRIPTION
Hey!

I fixed the issue #2. The problem is basically that you assumed the week starts on a Monday which would mean MON = 0, TUE = 1, ..., SUN = 6. However, the official ![cron documentation](https://man7.org/linux/man-pages/man5/crontab.5.html) states explicitely that their week starts on a Sunday meaning that SUN = 0, MON = 1, ..., SAT = 6.
We should implement the offical mapping, since this package tries to imitate the official cron. Using a week starting on Monday would be only inconsistent and a cause for mistakes.

I closed the pull request #1, because the changes are in here too. I accidentally merged into my master and created a new branch from there meaning that both changes are in this pull request: The addition of a scheduler and the fix of the weekday bug.

Below you can read the contents of pull request #1:

I really like your package and the way you built it. Real smart programming there!
I only missed one small feature, with which you can schedule tasks easily using a cron string.
This pull request implements this feature, so you can schedule tasks as easy as:

```python
from cron_validator import CronScheduler

cron_string = "*/1 * * * *"
scheduler = CronScheduler(cron_string)

while True:
    if scheduler.time_for_execution():
        # Get's called every full minute (excluding first iteration)
        print("Now is the next scheduled time.")
```

I also added testing for the part I contributed. It should work as expected.
(I think you may have a bug in your code, but I'll open an issue on that on your repo.) (EDIT: Fixed!)

Lastly, I also updated the README and the versioning number. Hope that was okay.

Cheers!
Davide