### PR TITLE
Eventual Building Fix

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,5 @@
 -r base.txt
-pytest>=3.6
+pytest>=4.6
 pytest-cov
 coveralls
 freezegun


### PR DESCRIPTION
This merge request should (hopefully) fix issue #4. When looking at the error stack of the travis build it reports a version conflict ```Requirement.parse('pytest>=4.6'))```. So, setting the minimal version of pytest to 4.6 should hopefully do the trick.