### PR TITLE
Allow month and day of week names

### DIFF
--- a/cron_validator/util.py
+++ b/cron_validator/util.py
@@ -1,4 +1,5 @@
 import datetime
+import re
 
 import dateutil.parser
 import pytz
@@ -29,3 +30,27 @@ def str_to_datetime(datetime_str, tz_name="UTC"):
     :return:
     """
     return dateutil.parser.parse(datetime_str).replace(tzinfo=get_tz(tz_name))
+
+
+def replace_names(expression):
+    """
+
+    :param expression:
+    :return:
+    """
+    parts = expression.split(" ")
+    month_names = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"]
+    day_of_week_names = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"]
+    month_names_re = re.compile(rf"(?<![\d\/])({'|'.join(month_names)})(?!\d)", re.IGNORECASE)
+    day_of_week_names_re = re.compile(rf"(?<![\d\/])({'|'.join(day_of_week_names)})(?!\d)", re.IGNORECASE)
+    parts[3] = re.sub(
+        month_names_re, 
+        lambda m: str(month_names.index(m.group().lower()) + 1), 
+        parts[3]
+    )
+    parts[4] = re.sub(
+        day_of_week_names_re, 
+        lambda m: str(day_of_week_names.index(m.group().lower())), 
+        parts[4]
+    )
+    return " ".join(parts)

--- a/cron_validator/validator.py
+++ b/cron_validator/validator.py
@@ -1,7 +1,7 @@
 from dateutil import rrule
 
 from .regexes import ElementPart, Version, element_kind_map, regex_dict
-from .util import ts_to_datetime
+from .util import replace_names, ts_to_datetime
 
 
 class CronValidator:
@@ -12,6 +12,7 @@ class CronValidator:
         :param str expression:
         :return:
         """
+        expression = replace_names(expression)
         parts = expression.split(" ")
         if len(parts) != 5:
             raise ValueError("Invalid expression")

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,6 +1,6 @@
 from dateutil import rrule
 
-from cron_validator.util import str_to_datetime
+from cron_validator.util import replace_names, str_to_datetime
 
 tz_name = "Asia/Ho_Chi_Minh"
 utc_tz = "UTC"
@@ -33,3 +33,12 @@ def test_iterator_day():
     assert delta.total_seconds() < 0
     for dt in rrule.rrule(rrule.MINUTELY, dtstart=dt1, until=dt2):
         print(dt)
+
+
+def test_replace_names():
+    assert replace_names("* * * */2,3 6") == "* * * */2,3 6"
+    assert replace_names("* * * may fri") == "* * * 5 5"
+    assert replace_names("* * * jan-sep,nov mon/2") == "* * * 1-9,11 1/2"
+    assert replace_names("* * * feb,aug,oct tue,WED,sAT") == "* * * 2,8,10 2,3,6"
+    assert replace_names("* * * MAR-apr thu-fri") == "* * * 3-4 4-5"
+    assert replace_names("* * * mAy,jun,JUL-DEC SUN/3") == "* * * 5,6,7-12 0/3"

--- a/test/test_valid_regex.py
+++ b/test/test_valid_regex.py
@@ -107,3 +107,32 @@ def test_validator_day_of_week_part():
     assert_validate_successfully("* * * * */6")
     assert_validate_fail("* * * * */0")
     assert_validate_fail("* * * * */7")
+
+
+def test_validator_month_names():
+    assert_validate_successfully("* * * jan *")
+    assert_validate_successfully("* * * FEB,mar,Apr *")
+    assert_validate_successfully("* * * MAY-JUL *")
+    assert_validate_successfully("* * * jun-Aug *")
+    assert_validate_successfully("* * * Sep,Oct *")
+    assert_validate_successfully("* * * dec/3 *")
+    assert_validate_fail("* * * January *")
+    assert_validate_fail("* * * jan1 *")
+    assert_validate_fail("* * * 1jan *")
+    assert_validate_fail("* * * 2/feb *")
+    assert_validate_fail("* * * */feb *")
+    assert_validate_fail("* * * NOV/0 *")
+
+
+def test_validator_day_of_week_names():
+    assert_validate_successfully("* * * * sun")
+    assert_validate_successfully("* * * * mon,TUE,Wed")
+    assert_validate_successfully("* * * * FRI-SAT")
+    assert_validate_successfully("* * * * wed/2")
+    assert_validate_fail("* * * * Sunday")
+    assert_validate_fail("* * * * sun,mon-fri")
+    assert_validate_fail("* * * * tue/0")
+    assert_validate_fail("* * * * */mon")
+    assert_validate_fail("* * * * 1/wed")
+    assert_validate_fail("* * * * mon/mon")
+


### PR DESCRIPTION
Hi, I'm using this package as part of [fbrettnich/hcloud-snapshot-as-backup](https://github.com/fbrettnich/hcloud-snapshot-as-backup) and noticed that names of months and days of week are currently not accepted.

According to the [crontab man page](https://man7.org/linux/man-pages/man5/crontab.5.html), names are part of the standard regardless of case:
> Names can also be used for the 'month' and 'day of week' fields.
       Use the first three letters of the particular day or month (case
       does not matter).  Ranges and lists of names are allowed.
       Examples: "mon,wed,fri", "jan-mar".

This pull request introduces the functionality to use them within this package. I thought that the easiest and least invasive way would be to just convert names to their corresponding integers while preventing unintended side-effects from happening (`Jan1 -> 11`, `2/Mar -> 2/2`, etc. should not happen). It is just a single function call to convert the expression before it is parsed. This way the rest of the code remains untouched, especially the datetime conversion/matching.

The pull request also includes some new tests to accomodate this functionality.