### PR TITLE
Avoid indexerror in replace names

### DIFF
--- a/cron_validator/util.py
+++ b/cron_validator/util.py
@@ -4,6 +4,10 @@ import re
 import dateutil.parser
 import pytz
 
+month_names = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"]
+day_of_week_names = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"]
+month_names_re = re.compile(rf"(?<![\d\/])({'|'.join(month_names)})(?!\d)", re.IGNORECASE)
+day_of_week_names_re = re.compile(rf"(?<![\d\/])({'|'.join(day_of_week_names)})(?!\d)", re.IGNORECASE)
 
 def get_tz(tz_name):
     """
@@ -39,18 +43,16 @@ def replace_names(expression):
     :return:
     """
     parts = expression.split(" ")
-    month_names = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"]
-    day_of_week_names = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"]
-    month_names_re = re.compile(rf"(?<![\d\/])({'|'.join(month_names)})(?!\d)", re.IGNORECASE)
-    day_of_week_names_re = re.compile(rf"(?<![\d\/])({'|'.join(day_of_week_names)})(?!\d)", re.IGNORECASE)
-    parts[3] = re.sub(
-        month_names_re, 
-        lambda m: str(month_names.index(m.group().lower()) + 1), 
-        parts[3]
-    )
-    parts[4] = re.sub(
-        day_of_week_names_re, 
-        lambda m: str(day_of_week_names.index(m.group().lower())), 
-        parts[4]
-    )
+    if len(parts) > 3:
+        parts[3] = re.sub(
+            month_names_re,
+            lambda m: str(month_names.index(m.group().lower()) + 1),
+            parts[3]
+        )
+    if len(parts) > 4:
+        parts[4] = re.sub(
+            day_of_week_names_re,
+            lambda m: str(day_of_week_names.index(m.group().lower())),
+            parts[4]
+        )
     return " ".join(parts)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -42,3 +42,5 @@ def test_replace_names():
     assert replace_names("* * * feb,aug,oct tue,WED,sAT") == "* * * 2,8,10 2,3,6"
     assert replace_names("* * * MAR-apr thu-fri") == "* * * 3-4 4-5"
     assert replace_names("* * * mAy,jun,JUL-DEC SUN/3") == "* * * 5,6,7-12 0/3"
+
+    assert replace_names("invalid_cron") == "invalid_cron"


### PR DESCRIPTION
vcoder4c/cron-validator#12 introduced a regression in that invalid cron entries (entries with fewer than 5 parts) were throwing IndexError. Fixed by ignoring invalid cron entries in `replace_names`.

Also moved the regex compilation outside `replace_names` to be reused in consecutive calls.